### PR TITLE
add-python-and-pipenv-binaries-to-Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,8 @@ RUN apt-get update && apt-get install -y python3.7-dev python3-distutils && apt-
 RUN rm -fr /usr/bin/python3 && ln /usr/bin/python3.7 /usr/bin/python3
 RUN ln /usr/bin/python3.7 /usr/bin/python
 
+# Install pip and pipenv
+RUN apt -y install python3-pip python3-dev
+RUN pip3 install pipenv
+
 USER ubuntu


### PR DESCRIPTION
I temporarily add CMD clause in Dockerfile to verify correctness:
![pipenv](https://user-images.githubusercontent.com/22542906/52270495-dab29980-2949-11e9-9716-e72c6a2ec6f5.png)

![pyversion](https://user-images.githubusercontent.com/22542906/52270506-e30ad480-2949-11e9-9667-0b5f862d1e8b.png)
